### PR TITLE
Bugfix: Allow mods to forcestop games

### DIFF
--- a/commands/mod/forcestop.js
+++ b/commands/mod/forcestop.js
@@ -3,10 +3,10 @@ import { GAMEBOT_PERMISSIONS } from '../../config/types.js'
 
 export default new BotCommand({
   name: 'forcestop',
-  aliases: ['stop'],
+  aliases: ['forceend'],
   description: 'Description',
   category: 'mod',
-  permissions: [GAMEBOT_PERMISSIONS.MOD, GAMEBOT_PERMISSIONS.OWNER],
+  permissions: [GAMEBOT_PERMISSIONS.MOD],
   dmCommand: false,
   args: [],
   run: function(msg, _args) {


### PR DESCRIPTION
Permissions were incorrect for the forcestop command. This fix changes that.